### PR TITLE
Exclude COURSE_FILES from root tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,5 +9,5 @@
     "noImplicitReturns": true,
     "declaration": true
   },
-  "exclude": ["**/node_modules/**"]
+  "exclude": ["**/node_modules/**", "COURSE_FILES/**"]
 }


### PR DESCRIPTION
Thanks as always for the brilliant workshop, Mike!

I have found that without this change, in [this lecture](https://frontendmasters.com/courses/monorepos/cleaning-output-rimraf/) when trying to build in the `packages` directory, there are errors preventing the build from succeeding due to files in the `COURSE_FILES`.

I am using yarn v4.1.2.

```bash
~/Learning/js-ts-monorepos/packages                                                                                                                                                                 
❯ yarn tsc -b .
yarn run v1.22.10

[...]

COURSE_FILES/09-internal-dependents/ui/tests/components/TeamSidebar.test.tsx:9:7 - error TS17004: Cannot use JSX unless the '--jsx' flag is provided.

[...]

Found 142 errors.

error Command failed with exit code 1.
```